### PR TITLE
Prepare 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,3 @@
 # 1.0.0
 
- - Support Mixin for ensuring a plugin has an `ecs_compatibility` method that is configurable from an `ecs_compatibility` option that accepts the literal `disabled` or an integer representing a major ECS version, using the implementation from Logstash core if available.
+ - Support Mixin for ensuring a plugin has an `ecs_compatibility` method that is configurable from an `ecs_compatibility` option that accepts the literal `disabled` or a v-prefixed integer representing a major ECS version (e.g., `v1`), using the implementation from Logstash core if available.

--- a/logstash-mixin-ecs_compatibility_support.gemspec
+++ b/logstash-mixin-ecs_compatibility_support.gemspec
@@ -1,9 +1,9 @@
 Gem::Specification.new do |s|
   s.name          = 'logstash-mixin-ecs_compatibility_support'
-  s.version       = '1.0.0.alpha'
+  s.version       = '1.0.0'
   s.licenses      = %w(Apache-2.0)
-  s.summary       = "Support for the ECS-Compatibility mode targeting Logstash 7.7, for plugins wishing to use this API on older Logstashes"
-  s.description   = "This gem is meant to be a dependency of any Logstash plugin that wishes to use the ECS-Compatibility mode introduced in 7.7 while maintaining backward-compatibility with earlier Logstashes. When used on older Logstash versions, it provides an implementation of ECS-Compatibility mode that can be controlled at the plugin instance level."
+  s.summary       = "Support for the ECS-Compatibility mode introduced in Logstash 7.x, for plugins wishing to use this API on older Logstashes"
+  s.description   = "This gem is meant to be a dependency of any Logstash plugin that wishes to use the ECS-Compatibility mode introduced in Logstash 7.x while maintaining backward-compatibility with earlier Logstash releases. When used on older Logstash versions, this adapter provides an implementation of ECS-Compatibility mode that can be controlled at the plugin instance level."
   s.authors       = %w(Elastic)
   s.email         = 'info@elastic.co'
   s.homepage      = 'https://github.com/logstash-plugins/logstash-mixin-ecs_compatibility_support'


### PR DESCRIPTION
In preparation for a stable 1.0 release, this PR does two things:
 - bumps the version
 - makes a small clarification to the changelog