### PR TITLE
add support for aliases in version-constrained implementations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ language: minimal
 matrix:
   include:
   - env: ELASTIC_STACK_VERSION=6.x
-  - env: ELASTIC_STACK_VERSION=7.6.2 # release pre introduction of core ECS-compatibility mode
+  - env: ELASTIC_STACK_VERSION=7.9.3 # last release pre introduction of core ECS-compatibility mode
   - env: ELASTIC_STACK_VERSION=7.x
   - env: ELASTIC_STACK_VERSION=7.x SNAPSHOT=true
   - env: ELASTIC_STACK_VERSION=8.x SNAPSHOT=true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
-# 1.0.0
+# 1.2.0
+ - Added support for resolution aliases, allowing a plugin that uses `ecs_select` to support multiple ECS versions with a single declaration.
 
+# 1.1.0
+ - Added support for `ecs_select` helper, allowing plugins to declare mappings that are selected during plugin instantiation.
+
+# 1.0.0
  - Support Mixin for ensuring a plugin has an `ecs_compatibility` method that is configurable from an `ecs_compatibility` option that accepts the literal `disabled` or a v-prefixed integer representing a major ECS version (e.g., `v1`), using the implementation from Logstash core if available.

--- a/README.md
+++ b/README.md
@@ -67,13 +67,13 @@ during initialization based on the instantiated plugin's effective
 mappings, because it allows those mappings to be side-by-side where they are
 unlikely to diverge and introduce bugs.
 
-1. Add version `~>1.1` of this gem as a runtime dependency of your Logstash plugin's `gemspec`:
+1. Add version `~>1.2` of this gem as a runtime dependency of your Logstash plugin's `gemspec`:
 
     ~~~ ruby
     Gem::Specification.new do |s|
       # ...
 
-      s.add_runtime_dependency 'logstash-mixin-ecs_compatibility_support', '~>1.1'
+      s.add_runtime_dependency 'logstash-mixin-ecs_compatibility_support', '~>1.2'
     end
     ~~~
 
@@ -95,6 +95,20 @@ unlikely to diverge and introduce bugs.
    whether that mode was explicitly defined for the plugin instance or implictly
    defined by the pipeline in which the plugin is run.
 
+   You can also optionally provide an alias mapping, for when your plugin supports
+   multiple versions of ECS that are largely identical to each other. This can be
+   especially helpful when using `ecs_select`.
+
+    ~~~ ruby
+    require 'logstash/plugin_mixins/ecs_compatibility_support'
+
+    class LogStash::Inputs::Foo < Logstash::Inputs::Base
+      include LogStash::PluginMixins::ECSCompatibilitySupport(:disabled,:v1,:v8 => :v1)
+
+      # ...
+    end
+    ~~~
+
 3. As in the simple usage example, you can use the `ecs_compatibility` method.
 
    But when supported versions are specified, you can also use the `ecs_select`
@@ -107,6 +121,9 @@ unlikely to diverge and introduce bugs.
         @field_hostip   = ecs_select[disabled: "ip",       v1: "[host][ip]"  ]
       end
     ~~~
+
+   If you initialized the mixin with an alias mapping, missing values will
+   be resolved by their alias.
 
    NOTE: `ecs_select` should only be used during plugin initialization and
    not during event-by-event processing.

--- a/lib/logstash/plugin_mixins/ecs_compatibility_support.rb
+++ b/lib/logstash/plugin_mixins/ecs_compatibility_support.rb
@@ -101,6 +101,10 @@ module LogStash
       end
     end
 
+    ##
+    # @override ECSCompatibilitySupport(*supported_versions, alias_map={})
+    #   @param supported_versions [Array[Symbol]]: the supported ECS versions
+    #   @param alias_map [Hash{Symbol=>Symbol}]: an optional mapping of aliases (keys) to supported version (values)
     def self.ECSCompatibilitySupport(*supported_versions)
       return ECSCompatibilitySupport if supported_versions.empty?
 

--- a/lib/logstash/plugin_mixins/ecs_compatibility_support/spec_helper.rb
+++ b/lib/logstash/plugin_mixins/ecs_compatibility_support/spec_helper.rb
@@ -28,15 +28,13 @@ module LogStash
       # ~~~
       module SpecHelper
         def ecs_compatibility_matrix(*supported_modes,&block)
-          if supported_modes.empty? || supported_modes.any? { |mode| !mode.kind_of?(Symbol) }
-            fail(ArgumentError, "ecs_compatibility_matrix(*supported_modes) requires one or more symbol supported_modes")
-          end
+          ecs_selector = Selector.new(*supported_modes)
 
-          supported_modes.each do |active_mode|
+          ecs_selector.ecs_modes_supported.each do |active_mode|
             context "`ecs_compatibility => #{active_mode}`" do
               let(:ecs_compatibility) { active_mode }
 
-              ecs_select = Selector::State.new(supported_modes, active_mode)
+              ecs_select = ecs_selector.state_for(active_mode)
               instance_exec(ecs_select, &block)
             end
           end

--- a/logstash-mixin-ecs_compatibility_support.gemspec
+++ b/logstash-mixin-ecs_compatibility_support.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = 'logstash-mixin-ecs_compatibility_support'
-  s.version       = '1.1.0'
+  s.version       = '1.2.0'
   s.licenses      = %w(Apache-2.0)
   s.summary       = "Support for the ECS-Compatibility mode introduced in Logstash 7.x, for plugins wishing to use this API on older Logstashes"
   s.description   = "This gem is meant to be a dependency of any Logstash plugin that wishes to use the ECS-Compatibility mode introduced in Logstash 7.x while maintaining backward-compatibility with earlier Logstash releases. When used on older Logstash versions, this adapter provides an implementation of ECS-Compatibility mode that can be controlled at the plugin instance level."

--- a/spec/logstash/plugin_mixins/ecs_compatibility_support/spec_helper_spec.rb
+++ b/spec/logstash/plugin_mixins/ecs_compatibility_support/spec_helper_spec.rb
@@ -6,14 +6,14 @@ require "logstash/plugin_mixins/ecs_compatibility_support/spec_helper"
 
 describe LogStash::PluginMixins::ECSCompatibilitySupport::SpecHelper, :ecs_compatibility_support do
   context '::ecs_compatibility_matrix(*modes)' do
-    ecs_compatibility_matrix(:disabled,:v1) do |ecs_select|
+    ecs_compatibility_matrix(:disabled,:v1,:v8 => :v1) do |ecs_select|
       it("sets `ecs_compatibility` with the current active mode `#{ecs_select.active_mode}`") do
         expect(ecs_compatibility).to eq(ecs_select.active_mode)
       end
       context 'the yielded value' do
         subject { ecs_select }
         it { is_expected.to be_a_kind_of LogStash::PluginMixins::ECSCompatibilitySupport::Selector::State }
-        its(:supported_modes) { is_expected.to contain_exactly(:disabled,:v1) }
+        its(:supported_modes) { is_expected.to contain_exactly(:disabled,:v1,:v8) }
         its(:active_mode) { is_expected.to be ecs_compatibility }
       end
     end

--- a/spec/logstash/plugin_mixins/ecs_compatibility_support_spec.rb
+++ b/spec/logstash/plugin_mixins/ecs_compatibility_support_spec.rb
@@ -155,5 +155,12 @@ describe 'LogStash::PluginMixins::ECSCompatibilitySupport()' do
       expect(selector_module.ecs_modes_supported).to contain_exactly(:disabled,:v1)
     end
   end
+  context 'with symbol arguments and alias mapping' do
+    it 'returns a properly-configured LogStash::PluginMixins::ECSCompatibilitySupport::Selector' do
+      selector_module = LogStash::PluginMixins::ECSCompatibilitySupport(:disabled,:v1,:v8 => :v1)
+      expect(selector_module).to be_a_kind_of(LogStash::PluginMixins::ECSCompatibilitySupport::Selector)
+      expect(selector_module.ecs_modes_supported).to contain_exactly(:disabled,:v1,:v8)
+    end
+  end
 end
 


### PR DESCRIPTION
While we have a large effort in-flight to add ECS v1 support for plugins in advance of Logstash 8's general availability, ECS v8 is set to release along-side Elastic Stack 8, and the delta is currently being scoped and is thus unknown. This means that as we get closer to the release of Logstash 8, we have a pending task to go back and add ECS v8 support to all plugins for which we recently added ECS v1 support.

These changes to the support adapter will allow plugin maintainers to describe ECS v8 as an alias for ECS v1 and provide only the delta in their usage of `ecs_select`, drastically reducing the overhead of implementing v8.

Where before, plugin maintainers were encouraged to describe the versions that they supported and _forced_ to provide side-by-side implementations for _all_ supported versions to each `ecs_select`:

~~~ ruby
require 'logstash/plugin_mixins/ecs_compatibility_support'

class LogStash::Inputs::Foo < Logstash::Inputs::Base
  include LogStash::PluginMixins::ECSCompatibilitySupport(:disabled, :v1)

  def register
    @this = ecs_select[disabled: "old",    v1: "new"]
    @that = ecs_select[disabled: "legacy", v1: "novel"]
  end
end
~~~

With these changes maintainers now can describe one implementation in terms of another, providing only the delta:

~~~ ruby
require 'logstash/plugin_mixins/ecs_compatibility_support'

class LogStash::Inputs::Foo < Logstash::Inputs::Base
  include LogStash::PluginMixins::ECSCompatibilitySupport(:disabled, :v1, :v8 => :v1)

  def register
    @this = ecs_select[disabled: "old",    v1: "new"]
    @that = ecs_select[disabled: "legacy", v1: "novel", v8:"shiny"]
  end
end
~~~

Plugin instantiation will be guarded to allow only the supported plugins, and usage of `ecs_select` will "fall through" the alias chain when a value is not provided. In the example above, when run in the new `v8` mode,  `@this`  will resolve to `"new"` by the alias from `v8 => v1`, while `@that` will resolve to `"shiny"` because the value is explicitly given.
