### PR TITLE
enhance target check to support codec.target

### DIFF
--- a/lib/logstash/plugin_mixins/ecs_compatibility_support/target_check.rb
+++ b/lib/logstash/plugin_mixins/ecs_compatibility_support/target_check.rb
@@ -30,13 +30,45 @@ module LogStash
 
         ##
         # Check whether `target` is specified.
+        # For the majority of plugins, they don't have `codec`, hence does a simple check on `target`
+        # The rest of plugins, mostly input plugins, if the `codec` support `target`, check whether `codec.target` is specified
         #
         # @return [nil] if target is unspecified and ECS compatibility is disabled
-        # @return [true, false]
+        # @return [false, log_msg] when target is not set to the correct field
+        # @return [true] when target is set
         def target_set?
-          return true unless target.nil?
           return nil if ecs_compatibility == :disabled
-          false # target isn't set
+
+          if self.respond_to?(:codec) && codec.respond_to?(:target)
+            if target && codec.target
+              #  targeting both is not good.
+              msg = "ECS compatibility is enabled but `target` options were set in both codec " +
+                "and plugin. This causes duplication of data in the same event. It is recommended to set " +
+                "`codec => #{codec.config_name} { target => #{codec.target.inspect} }` " +
+                "and remove `target => #{target.inspect}`"
+              [false, msg]
+            elsif target && !codec.target
+              # setting `target` causes `[event][original]` nested in `target`
+              msg = "ECS compatibility is enabled and `target` was set. " +
+                "It is recommended to set `codec => #{codec.config_name} { target => #{target.inspect} }` " +
+                "to have [event][original] in top-level"
+              [false, msg]
+            elsif !target && codec.target
+              # setting codec target is desired
+              [true]
+            else
+              # both are not set
+              msg = "ECS compatibility is enabled but `target` option was not specified in codec. " +
+                "This may cause fields to be set at the top-level of the event where they are likely to clash with the Elastic Common Schema. " +
+                "It is recommended to set `codec => #{codec.config_name} { target => YOUR_TARGET_FIELD_NAME }` " +
+                "to avoid potential schema conflicts (if your data is ECS compliant " +
+                "or non-conflicting, feel free to ignore this message)"
+              [false, msg]
+            end
+          else
+            return [true] unless target.nil?
+            [false, TARGET_NOT_SET_MESSAGE] # target isn't set
+          end
         end
 
         module RegisterDecorator
@@ -46,7 +78,8 @@ module LogStash
           # @override
           def register
             super.tap do
-              logger.info(TARGET_NOT_SET_MESSAGE) if target_set? == false
+              is_set, log_msg = target_set?
+              logger.info(log_msg) if is_set == false
             end
           end
 

--- a/logstash-mixin-ecs_compatibility_support.gemspec
+++ b/logstash-mixin-ecs_compatibility_support.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = 'logstash-mixin-ecs_compatibility_support'
-  s.version       = '1.3.0'
+  s.version       = '1.3.1'
   s.licenses      = %w(Apache-2.0)
   s.summary       = "Support for the ECS-Compatibility mode introduced in Logstash 7.x, for plugins wishing to use this API on older Logstashes"
   s.description   = "This gem is meant to be a dependency of any Logstash plugin that wishes to use the ECS-Compatibility mode introduced in Logstash 7.x while maintaining backward-compatibility with earlier Logstash releases. When used on older Logstash versions, this adapter provides an implementation of ECS-Compatibility mode that can be controlled at the plugin instance level."

--- a/logstash-mixin-ecs_compatibility_support.gemspec
+++ b/logstash-mixin-ecs_compatibility_support.gemspec
@@ -21,4 +21,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec', '~> 3.9'
   s.add_development_dependency 'rspec-its', '~>1.3'
   s.add_development_dependency 'logstash-codec-plain'
+  s.add_development_dependency 'logstash-codec-json'
 end

--- a/spec/logstash/plugin_mixins/ecs_compatibility_support/target_check_spec.rb
+++ b/spec/logstash/plugin_mixins/ecs_compatibility_support/target_check_spec.rb
@@ -88,19 +88,19 @@ describe LogStash::PluginMixins::ECSCompatibilitySupport::TargetCheck do
           end
         end
 
-        it 'warns when target and codec.target are not set' do
+        it 'does not warn when target and codec.target are not set' do
           plugin = plugin_class.new('ecs_compatibility' => 'v1')
           allow( plugin.logger ).to receive(:info)
           expect( plugin.register ).to eql 42
-          expect( plugin.logger ).to have_received(:info).with(a_string_including "ECS compatibility is enabled but `target` option was not specified in codec.")
+          expect( plugin.logger ).to_not have_received(:info).with(a_string_including "`target`")
         end
 
         it 'warns when target and codec.target are set' do
           json_codec = LogStash::Codecs::JSON.new('ecs_compatibility' => 'v1', 'target' => 'bar')
           plugin = plugin_class.new('ecs_compatibility' => 'v1', 'target' => 'foo', 'codec' => json_codec )
-          allow( plugin.logger ).to receive(:info)
+          allow( plugin.logger ).to receive(:warn)
           expect( plugin.register ).to eql 42
-          expect( plugin.logger ).to have_received(:info).with(a_string_including "ECS compatibility is enabled but `target` options were set")
+          expect( plugin.logger ).to have_received(:warn).with(a_string_including "This plugin and its codec both specify a `target` option")
         end
 
         it 'warns when target is set and codec.target is not set' do
@@ -108,7 +108,7 @@ describe LogStash::PluginMixins::ECSCompatibilitySupport::TargetCheck do
           plugin = plugin_class.new('ecs_compatibility' => 'v1', 'target' => 'foo', 'codec' => json_codec )
           allow( plugin.logger ).to receive(:info)
           expect( plugin.register ).to eql 42
-          expect( plugin.logger ).to have_received(:info).with(a_string_including "ECS compatibility is enabled and `target` was set")
+          expect( plugin.logger ).to have_received(:info).with(a_string_including "but the codec's `target` was left unspecified")
         end
 
         it 'does not warn when target is not set and codec.target is set' do
@@ -116,7 +116,7 @@ describe LogStash::PluginMixins::ECSCompatibilitySupport::TargetCheck do
           plugin = plugin_class.new('ecs_compatibility' => 'v1', 'target' => 'foo', 'codec' => json_codec )
           allow( plugin.logger ).to receive(:info)
           expect( plugin.register ).to eql 42
-          expect( plugin.logger ).to_not have_received(:info).with(a_string_including "`ECS compatibility")
+          expect( plugin.logger ).to_not have_received(:info).with(a_string_including "`target`")
         end
       end
     end


### PR DESCRIPTION
The majority of plugins satisfy with `target` check when ECS is enabled. Some input plugins have default codec `json` which does the same target check as the input plugins. However,  there is no easy way to pass `target` config from input to codec. Missing `codec.target` setting cause `[event][original]` nested in `target` instead of staying in top-level ECS fields.

This PR adds checking and log messages to help users config in the right way.
When the plugin has `codec` and the codec has `target`, it is recommended to set the `target` in codec