### PR TITLE
target-check: provide guidance when codec also supports target directive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.3.1
+ - Fix: target check helper provides better guidance when both a plugin and its codec provide `target` options [#9](https://github.com/logstash-plugins/logstash-mixin-ecs_compatibility_support/pull/9)
+
 # 1.3.0
  - Feat: introduce a target check helper [#6](https://github.com/logstash-plugins/logstash-mixin-ecs_compatibility_support/pull/6) 
 

--- a/lib/logstash/plugin_mixins/ecs_compatibility_support/target_check.rb
+++ b/lib/logstash/plugin_mixins/ecs_compatibility_support/target_check.rb
@@ -21,11 +21,6 @@ module LogStash
           base.prepend(RegisterDecorator)
         end
 
-        TARGET_NOT_SET_MESSAGE = ("ECS compatibility is enabled but `target` option was not specified. " +
-            "This may cause fields to be set at the top-level of the event where they are likely to clash with the Elastic Common Schema. " +
-            "It is recommended to set the `target` option to avoid potential schema conflicts (if your data is ECS compliant " +
-            "or non-conflicting, feel free to ignore this message)").freeze
-
         private
 
         ##
@@ -39,14 +34,63 @@ module LogStash
           false # target isn't set
         end
 
+        ##
+        # Check whether a codec is present and specifies a target.
+        #
+        # @return [nil] if codec not present or codec does not support target
+        # @return [true,false]
+        def codec_target_set?
+          return nil unless respond_to?(:codec)
+          return nil unless codec.respond_to?(:target)
+          !codec.target.nil?
+        end
+
         module RegisterDecorator
+
+          ECS_TARGET_NOT_SET_MESSAGE = ("ECS compatibility is enabled but `target` option was not specified. " +
+            "This may cause fields to be set at the top-level of the event where they are likely to clash with the Elastic Common Schema. " +
+            "It is recommended to set the `target` option to avoid potential schema conflicts " +
+            "(if your data is ECS compliant or non-conflicting, feel free to ignore this message)").freeze
+
+          ECS_TARGET_NOT_SET_PREFER_CODEC_MESSAGE = ("ECS compatibility is enabled but `target` option was not specified for this plugin or its codec." +
+            "This may cause fields to be set at the top-level of the event where they are likely to clash with the Elastic Common Schema. " +
+            "When a plugin and its codec both provide a `target` option, it is recommended to set the `target` option on the codec to avoid potential schema conflicts " +
+            "(if your data is ECS compliant or non-conflicting, feel free to ignore this message)."
+          ).freeze
+
+          MULTIPLE_TARGETS_SET_MESSAGE = ("This plugin and its codec are both configured with a `target` option, which can lead to surprising results. " +
+            "In general, it is recommended to ONLY set the codec's `target`.").freeze
+
+          PREFER_CODEC_TARGET_MESSAGE_TEMPLATE = ("Both this plugin and its codec provide a `target` option, but the codec's `target` was left unspecified. "+
+            "In general, it is recommended to only set the codec's `target`. "+
+            "To do so, remove the `target` directive from this plugin and instead define the codec with `codec => %s { target => %p }`").freeze
 
           ##
           # Logs an info message when ecs_compatibility is enabled but plugin has no `target` configuration specified.
           # @override
           def register
             super.tap do
-              logger.info(TARGET_NOT_SET_MESSAGE) if target_set? == false
+              plugin_targeted = target_set?
+              codec_targeted = codec_target_set?
+
+              if plugin_targeted
+                if codec_targeted
+                  # both is not good. prefer codec.
+                  logger.warn(MULTIPLE_TARGETS_SET_MESSAGE)
+                elsif codec_targeted == false
+                  # prefer codec's target option
+                  logger.warn(PREFER_CODEC_TARGET_MESSAGE_TEMPLATE % [codec.config_name, target])
+                end
+              elsif (plugin_targeted == false)
+                # ECS enabled and plugin not targeted
+                if codec_targeted.nil?
+                  # codec does not support target
+                  logger.info(ECS_TARGET_NOT_SET_MESSAGE)
+                elsif codec_targeted == false
+                  # codec supports target, but it is unspecified
+                  logger.info(ECS_TARGET_NOT_SET_PREFER_CODEC_MESSAGE)
+                end
+              end
             end
           end
 

--- a/logstash-mixin-ecs_compatibility_support.gemspec
+++ b/logstash-mixin-ecs_compatibility_support.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = 'logstash-mixin-ecs_compatibility_support'
-  s.version       = '1.3.0'
+  s.version       = '1.3.1'
   s.licenses      = %w(Apache-2.0)
   s.summary       = "Support for the ECS-Compatibility mode introduced in Logstash 7.x, for plugins wishing to use this API on older Logstashes"
   s.description   = "This gem is meant to be a dependency of any Logstash plugin that wishes to use the ECS-Compatibility mode introduced in Logstash 7.x while maintaining backward-compatibility with earlier Logstash releases. When used on older Logstash versions, this adapter provides an implementation of ECS-Compatibility mode that can be controlled at the plugin instance level."

--- a/spec/logstash/plugin_mixins/ecs_compatibility_support/target_check_spec.rb
+++ b/spec/logstash/plugin_mixins/ecs_compatibility_support/target_check_spec.rb
@@ -10,12 +10,46 @@ require 'logstash/outputs/base'
 require "logstash/plugin_mixins/ecs_compatibility_support/target_check"
 
 describe LogStash::PluginMixins::ECSCompatibilitySupport::TargetCheck do
+  subject(:plugin) { plugin_class.new(plugin_params) }
+  let(:plugin_params) { Hash.new }
 
-  describe "check_target_set_in_ecs_mode" do
+  let(:logger) { double("Logger").as_null_object }
+  before { allow(plugin).to receive(:logger).and_return(logger)}
 
-    context 'with a plugin' do
+  context 'with a plugin' do
 
-      subject(:plugin_class) do
+    shared_examples "check target set" do
+      context("ECS disabled") do
+        let(:plugin_params) { super().merge('ecs_compatibility' => 'disabled') }
+        it 'does not log info about setting the target' do
+          expect(plugin.register).to eql 42
+          expect(plugin.logger).to_not have_received(:info).with(a_string_including "`target` option")
+        end
+      end
+
+      context "ECS enabled" do
+        let(:plugin_params) { super().merge('ecs_compatibility' => 'v1') }
+
+        context "when target not set" do
+          it 'emits a helpful info log' do
+            expect(plugin.register).to eql 42
+            expect(plugin.logger).to have_received(:info).with(a_string_including("ECS compatibility is enabled but `target` option was not specified.")
+                                                                 .and(including "set the `target` option to avoid potential schema conflicts"))
+          end
+        end
+
+        context "when target is provided" do
+          let(:plugin_params) { super().merge('target' => 'foo') }
+          it 'does not emit an info log about setting the target' do
+            expect(plugin.register).to eql 42
+            expect(plugin.logger).to_not have_received(:info).with(a_string_including "`target` option")
+          end
+        end
+      end
+    end
+
+    context "filter" do
+      let(:plugin_class) do
         Class.new(LogStash::Filters::Base) do
           include LogStash::PluginMixins::ECSCompatibilitySupport
           include LogStash::PluginMixins::ECSCompatibilitySupport::TargetCheck
@@ -23,45 +57,107 @@ describe LogStash::PluginMixins::ECSCompatibilitySupport::TargetCheck do
           config :target, :validate => :string
 
           def register; 42 end
-
         end
       end
 
-      it 'skips check when ECS disabled' do
-        plugin = plugin_class.new('ecs_compatibility' => 'disabled')
-        allow( plugin.logger ).to receive(:info)
-        expect( plugin.register ).to eql 42
-        expect( plugin.logger ).to_not have_received(:info).with(a_string_including "`target` option")
-      end
-
-      it 'warns when target is not set in ECS mode' do
-        plugin = plugin_class.new('ecs_compatibility' => 'v1')
-        allow( plugin.logger ).to receive(:info)
-        expect( plugin.register ).to eql 42
-        expect( plugin.logger ).to have_received(:info).with(a_string_including "ECS compatibility is enabled but `target` option was not specified.")
-      end
-
-      it 'does not warn when target is set' do
-        plugin = plugin_class.new('ecs_compatibility' => 'v1', 'target' => 'foo')
-        allow( plugin.logger ).to receive(:info)
-        expect( plugin.register ).to eql 42
-        expect( plugin.logger ).to_not have_received(:info).with(a_string_including "`target` option")
-      end
-
+      include_examples("check target set")
     end
 
-    it 'fails check when no target config' do
-      plugin_class = Class.new(LogStash::Filters::Base) do
+    context "input" do
+      let(:plugin_class) do
+        Class.new(LogStash::Inputs::Base) do
+          include LogStash::PluginMixins::ECSCompatibilitySupport
+          include LogStash::PluginMixins::ECSCompatibilitySupport::TargetCheck
+
+          config :target, :validate => :string
+
+          def register; 42 end
+        end
+      end
+      let(:codec) { codec_class.new(codec_params) }
+      let(:codec_params) { Hash.new }
+
+      context 'when configured with a codec that does not support `target`' do
+        let(:codec_class) do
+          Class.new(LogStash::Codecs::Base)
+        end
+        let(:plugin_params) { super().merge('codec' => codec) }
+
+        include_examples("check target set")
+      end
+
+      context 'when configured with a codec that supports `target`' do
+        let(:codec_class) do
+          Class.new(LogStash::Codecs::Base) do
+            config_name :dummy
+            config :target, :validate => :string
+          end
+        end
+        let(:plugin_params) { super().merge('codec' => codec) }
+
+
+        context "and neither the input's target nor the codec's target is set" do
+          context "and ECS compatibility is enabled" do
+            let(:plugin_params) { super().merge('ecs_compatibility' => 'v1') }
+            it "logs info advocating for setting the codec's target" do
+              expect(plugin.register).to eq(42)
+              expect(plugin.logger).to have_received(:info).with(a_string_including "set the `target` option on the codec")
+            end
+          end
+          context "and ECS compatibility is disabled" do
+            let(:plugin_params) { super().merge('ecs_compatibility' => 'disabled') }
+            it "does not log info about targets" do
+              expect(plugin.register).to eq(42)
+              expect(plugin.logger).to_not have_received(:info).with(a_string_including "`target`")
+            end
+          end
+        end
+
+        context "and both the input's target and the codec's target are specified" do
+          let(:plugin_params) { super().merge('target' => 'outer') }
+          let(:codec_params) { super().merge('target' => 'inner') }
+
+          it 'logs a warning about target being specified multiple places' do
+            expect(plugin.register).to eq(42)
+            expect(plugin.logger).to have_received(:warn).with(a_string_including "This plugin and its codec are both configured with a `target` option")
+          end
+        end
+
+        context "and target is provided in the input but not the codec" do
+          let(:plugin_params) { super().merge('target' => 'outer') }
+
+          it "logs info about preferring the codec's target" do
+            expect(plugin.register).to eq(42)
+            expect(plugin.logger).to have_received(:warn).with(a_string_including("codec's `target` was left unspecified")
+                                                                 .and(including "only set the codec's `target`")
+                                                                 .and(including "`codec => dummy { target => \"outer\" }`"))
+          end
+        end
+
+        context "and target is provided in the codec but not the input" do
+          let(:codec_params) { super().merge('target' => 'inner') }
+
+          it "does not log info about target" do
+            expect(plugin.register).to eq(42)
+            expect(plugin.logger).to_not have_received(:info).with(a_string_including("`target`"))
+          end
+        end
+      end
+    end
+  end
+
+  context 'with a plugin that does not have target config' do
+    let(:plugin_class) do
+      Class.new(LogStash::Filters::Base) do
         include LogStash::PluginMixins::ECSCompatibilitySupport
         include LogStash::PluginMixins::ECSCompatibilitySupport::TargetCheck
 
         def register; end
-
       end
-      plugin = plugin_class.new('ecs_compatibility' => 'v1')
+    end
+    it 'raises an error at registration' do
       expect { plugin.register }.to raise_error NameError, /\btarget\b/
     end
-
   end
 
 end

--- a/spec/logstash/plugin_mixins/ecs_compatibility_support/target_check_spec.rb
+++ b/spec/logstash/plugin_mixins/ecs_compatibility_support/target_check_spec.rb
@@ -96,15 +96,15 @@ describe LogStash::PluginMixins::ECSCompatibilitySupport::TargetCheck do
         let(:plugin_params) { super().merge('codec' => codec) }
 
 
-        context "and neither the input's target nor the codec's target is set" do
-          context "and ECS compatibility is enabled" do
+        context "when neither the input's target nor the codec's target is set" do
+          context "when ECS compatibility is enabled" do
             let(:plugin_params) { super().merge('ecs_compatibility' => 'v1') }
             it "logs info advocating for setting the codec's target" do
               expect(plugin.register).to eq(42)
               expect(plugin.logger).to have_received(:info).with(a_string_including "set the `target` option on the codec")
             end
           end
-          context "and ECS compatibility is disabled" do
+          context "when ECS compatibility is disabled" do
             let(:plugin_params) { super().merge('ecs_compatibility' => 'disabled') }
             it "does not log info about targets" do
               expect(plugin.register).to eq(42)
@@ -113,7 +113,7 @@ describe LogStash::PluginMixins::ECSCompatibilitySupport::TargetCheck do
           end
         end
 
-        context "and both the input's target and the codec's target are specified" do
+        context "when both the input's target and the codec's target are specified" do
           let(:plugin_params) { super().merge('target' => 'outer') }
           let(:codec_params) { super().merge('target' => 'inner') }
 
@@ -123,7 +123,7 @@ describe LogStash::PluginMixins::ECSCompatibilitySupport::TargetCheck do
           end
         end
 
-        context "and target is provided in the input but not the codec" do
+        context "when target is provided in the input but not the codec" do
           let(:plugin_params) { super().merge('target' => 'outer') }
 
           it "logs info about preferring the codec's target" do
@@ -134,7 +134,7 @@ describe LogStash::PluginMixins::ECSCompatibilitySupport::TargetCheck do
           end
         end
 
-        context "and target is provided in the codec but not the input" do
+        context "when target is provided in the codec but not the input" do
           let(:codec_params) { super().merge('target' => 'inner') }
 
           it "does not log info about target" do


### PR DESCRIPTION
When a targetable plugin is configured with a codec that also supports a target
directive, log guidance toward using only the codec's target.

From the specs:
~~~
LogStash::PluginMixins::ECSCompatibilitySupport::TargetCheck
  with a plugin
    filter
      ECS disabled
        does not log info about setting the target
      ECS enabled
        when target not set
          emits a helpful info log
        when target is provided
          does not emit an info log about setting the target
    input
      when configured with a codec that does not support `target`
        ECS disabled
          does not log info about setting the target
        ECS enabled
          when target not set
            emits a helpful info log
          when target is provided
            does not emit an info log about setting the target
      when configured with a codec that supports `target`
        when neither the input's target nor the codec's target is set
          when ECS compatibility is enabled
            logs info advocating for setting the codec's target
          when ECS compatibility is disabled
            does not log info about targets
        when both the input's target and the codec's target are specified
          logs a warning about target being specified multiple places
        when target is provided in the input but not the codec
          logs info about preferring the codec's target
        when target is provided in the codec but not the input
          does not log info about target
  with a plugin that does not have target config
    raises an error at registration
~~~

Co-authored-by: @kaisecheng
Closes: logstash-plugins/logstash-mixin-ecs_compatibility_support#8